### PR TITLE
ドロワーメニューが横スクロールでで見えてしまう問題を修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -119,7 +119,7 @@ dd {
         row-gap: 24px;
         font-size: 24px;
 
-        position: absolute;
+        position: fixed;
         z-index: 1;
         top: 0;
         left: 100%;


### PR DESCRIPTION
凡ミスでドロワーメニューが画面外にある時、横スクロールできて、見えるようになってしまっていました💦
現在修正済みです。前回プルリク時に確認不足で申し訳ありませんでしたm(__)m
![respone](https://user-images.githubusercontent.com/9443634/129303838-72c25205-93b4-4a6b-a9cc-e43e662e20f6.gif)
