### PR TITLE
ドロワーメニューの開閉ボタンが機能しない問題を修正した

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,14 @@ $(function () {
     $('.header').load('header.html');
 
     // SP用メニューの開閉
-    $('.drawer-menu-btn').on('click', function () {
+    $(document).on('click', '.drawer-menu-btn', function () {
+        const btn = $('.drawer-menu-btn');
+        if (btn.text() == 'close') {
+            btn.text('menu');
+        } else {
+            btn.text('close');
+        }
+
         $('.navbar__nav__menu').toggleClass('show');
     });
-})
+});


### PR DESCRIPTION
本日、ドロワーメニューの開閉ボタンが機能しない問題を確認しました。
（クリックしてもドロワーメニューが現れない）

なので、これを修正しました。